### PR TITLE
Add password handling

### DIFF
--- a/kong/plugins/basicauth2keyauth/handler.lua
+++ b/kong/plugins/basicauth2keyauth/handler.lua
@@ -40,6 +40,12 @@ local function retrieve_credentials(request, header_name, conf)
         end
 
         username = basic_parts[1]
+        password = basic_parts[2]
+
+        if password ~= "" then
+          -- if password exists, we don't want to use that as api key
+          return
+        end
       end
     end
   end

--- a/spec/basicauth2keyauth/01-access_spec.lua
+++ b/spec/basicauth2keyauth/01-access_spec.lua
@@ -75,5 +75,17 @@ describe("Plugin: key-auth (access)", function()
       local header_value = assert.request(res).has.header("apikey_from_basicauth")
       assert.equal("632d187cde1f395f3fb17e9783748d101b70174988a8e148bc7bc20f63453ea5", header_value)
     end)
+    it("generates nothing if basic auth has the password part", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Host"] = "host2.com",
+          ["Authorization"] = "Basic YXBpMTIzNDpwYXNzd29yZAo=" -- "api1234:password"
+        }
+      })
+      assert.res_status(200, res)
+      assert.request(res).has.no.header("apikey_from_basicauth")
+    end)
   end)
 end)


### PR DESCRIPTION
This pr correctly handles the password part in basic_auth if we are trying to use it as api_key.

- If it's a normal basic auth, with `username:password`, we should do nothing
- If it's `username:`, we then try to add a api_key header